### PR TITLE
feat: clarify matching behavior in UI

### DIFF
--- a/lib/rollout/ui/views/features/index.slim
+++ b/lib/rollout/ui/views/features/index.slim
@@ -13,9 +13,7 @@ h2.font-semibold.text-xl.text-gray-500.pt-12.flex.items-center
   table.text-sm.w-100.text-left.w-full
     thead.font-semibold.text-gray-500.border-b.border-gray-200
       th.pb-2.pr-3 Name
-      th.pb-2.pr-3 Percentage
-      th.pb-2.pr-3 Groups
-      th.pb-2.pr-3 Users
+      th.pb-2.pr-3 Active for
       - if @rollout.respond_to?(:logging)
         th.pb-2.pr-3 Updated
       th.pl-2
@@ -29,17 +27,23 @@ h2.font-semibold.text-xl.text-gray-500.pt-12.flex.items-center
               = feature_name
             div.text-gray-500.text-xs = feature.data['description']
           td.py-2.whitespace-no-wrap
-            - if feature.percentage == 0
-              span.text-gray-400 #{feature.percentage}%
+            - if feature.groups.empty? && feature.users.count == 0 && feature.percentage == 0
+              span No one
+            - elsif feature.groups.include?(:all) || feature.percentage == 100
+              span Everyone
             - else
-              | #{feature.percentage}%
-          td.py-2.whitespace-no-wrap
-            = feature.groups.join(', ')
-          td.py-2.whitespace-no-wrap
-            - if feature.users.count == 0
-              span.text-gray-400 = feature.users.count
-            - else
-              = feature.users.count
+              - parts = []
+              - parts << "#{feature.percentage}% of all users" if feature.percentage > 0
+              - parts << "any member in [#{feature.groups.join(', ')}]" if !feature.groups.empty?
+              - parts << "#{feature.users.count} specific users" if feature.users.count > 0
+              
+              - if parts.size == 1
+                = parts.first.capitalize
+              - elsif parts.size == 2
+                = "#{parts.first} and #{parts.last}".capitalize
+              - elsif parts.size == 3
+                = "#{parts.first}, #{parts[1]}, and #{parts.last}".capitalize
+
           - if @rollout.respond_to?(:logging)
             td.py-2.whitespace-no-wrap
               = time_ago(@rollout.logging.updated_at(feature_name))

--- a/lib/rollout/ui/views/features/show.slim
+++ b/lib/rollout/ui/views/features/show.slim
@@ -35,7 +35,10 @@ main.p-6.bg-gray-100.max-w-lg.w-full.text-sm.rounded-sm
             = group
 
     .mb-5
-      label.block.text-gray-500.mb-2(for='percentage') Percentage
+      label.block.text-gray-500.mb-2(for='percentage') 
+        | Percentage
+        span.ml-1.text-gray-400
+          | (⚠️ applies to the entire user base)
       input.appearance-none.border.rounded-sm.w-full.py-2.px-4.text-gray-600.leading-relaxed.bg-white(
         name='percentage'
         id='percentage'
@@ -46,7 +49,10 @@ main.p-6.bg-gray-100.max-w-lg.w-full.text-sm.rounded-sm
       )
 
     .mb-5
-      label.block.text-gray-500.mb-2 Users
+      label.block.text-gray-500.mb-2
+        | Users
+        span.ml-1.text-gray-400
+          | (active regardless of groups and percentage)
 
       - if @feature.users.count > 150
         .appearance-none.border.rounded-sm.w-full.py-2.px-4.text-gray-600.leading-relaxed.bg-gray-100
@@ -61,6 +67,20 @@ main.p-6.bg-gray-100.max-w-lg.w-full.text-sm.rounded-sm
         )
           = @feature.users.join(', ')
 
+    .mb-5
+      label.block.text-gray-500.mb-2 
+        span.flex.items-center.cursor-pointer.select-none onclick="toggleCollapsible('matching-explanation')"
+          | How does matching work? 
+          span.ml-2.text-gray-400#matching-toggle ▶
+      .appearance-none.border.rounded-sm.w-full.py-3.px-4.text-gray-600.leading-relaxed.bg-gray-50#matching-explanation style="display:none"
+        p.mb-2
+          | <strong>$rollout.active?(:#{@feature.name})</strong><br>Will match only if percentage is set to 100
+        p.mb-2
+          | <strong>$rollout.active?(:#{@feature.name}, manolito)</strong><br>will match if any of the following is true: 
+          ul
+            li - manolito is in any of the active groups
+            li - manolito is in the specific users list
+            li - manolito falls inside the X% of the entire user base, regardless of groups and the specific users list
   .flex.items-center.justify-end
     form action=delete_feature_path(@feature.name) method='POST'
       button.mr-5.text-gray-600(class='hover:underline' type='submit' onclick="return confirm('Are you sure you want to delete #{sanitized_name(@feature.name)}?')")
@@ -75,3 +95,18 @@ main.p-6.bg-gray-100.max-w-lg.w-full.text-sm.rounded-sm
 - history_events = @rollout.respond_to?(:logging) ? @rollout.logging.events(@feature.name).reverse : []
 
 == slim :"features/partials/event_log", locals: { events: history_events }
+
+// Add JavaScript for collapsible functionality at the bottom of the file
+javascript:
+  function toggleCollapsible(id) {
+    const element = document.getElementById(id);
+    const toggle = document.getElementById('matching-toggle');
+    
+    if (element.style.display === 'none') {
+      element.style.display = 'block';
+      toggle.innerHTML = '▼';
+    } else {
+      element.style.display = 'none';
+      toggle.innerHTML = '▶';
+    }
+  }


### PR DESCRIPTION
Adds clarifications to the input labels, and adds a (collapsed by default) section explaining how matching works:
<img width="567" alt="Screenshot 2025-02-27 at 11 50 36" src="https://github.com/user-attachments/assets/3d72e542-3b87-4bfb-8337-e2301d0f6790" />

Merges the users, groups and percentage columns into a single column that describes exactly who will get the feature:
<img width="1306" alt="Screenshot 2025-02-27 at 11 50 07" src="https://github.com/user-attachments/assets/fb6ae07e-bfc9-46ad-bd56-95a8043a6ba2" />
